### PR TITLE
feat: adds --package arg to glob filter to a package name

### DIFF
--- a/dragon_runner/src/cli.py
+++ b/dragon_runner/src/cli.py
@@ -28,6 +28,7 @@ class RunnerArgs(NamedTuple):
     output: str = ""
     failure_log: str = ""
     debug_package: str = ""
+    package_filter: str = ""
     timeout: float = 2.0
     time: bool = False
     verbosity: int = 0
@@ -53,6 +54,7 @@ def parse_runner_args(argv_skip: int=1) -> RunnerArgs:
     parser.add_argument("--timeout", type=float, default=2.0)
     parser.add_argument("--verify", action="store_true")
     parser.add_argument("--debug-package", default="")
+    parser.add_argument("-p", "--package", dest="package_filter", default="", help="Filter packages by glob pattern (case insensitive)")
     parser.add_argument("-t", "--time", action="store_true")
     parser.add_argument("-v", "--verbosity", action="count", default=0)
     parser.add_argument("-s", "--show-testcase", action="store_true")

--- a/dragon_runner/src/config.py
+++ b/dragon_runner/src/config.py
@@ -163,11 +163,12 @@ class Config:
     """
     An in memory representation of the JSON configuration file which directs the tester. 
     """
-    def __init__(self, config_path: str, config_data: Dict, debug_package: Optional[str]):
+    def __init__(self, config_path: str, config_data: Dict, debug_package: Optional[str], package_filter: str = ""):
         self.name               = Path(config_path).stem
         self.config_path        = os.path.abspath(config_path)
         self.config_data        = config_data
         self.debug_package      = debug_package
+        self.package_filter     = package_filter
         self.test_dir           = resolve_relative(config_data['testDir'],
                                                    os.path.abspath(config_path))
         self.executables        = self.parse_executables(config_data['testedExecutablePaths'],
@@ -269,4 +270,6 @@ def load_config(config_path: str, args: Optional[RunnerArgs]=None) -> Optional[C
         log("Config Error: Failed to parse config: ", config_path)
         return None
 
-    return Config(config_path, config_data, args.debug_package if args else None)
+    debug_package = args.debug_package if args else None
+    package_filter = args.package_filter if args else ""
+    return Config(config_path, config_data, debug_package, package_filter)

--- a/dragon_runner/src/harness.py
+++ b/dragon_runner/src/harness.py
@@ -1,4 +1,5 @@
 import csv
+import fnmatch
 from colorama                   import Fore
 from typing                     import Any, List, Dict, Optional, Set
 from dragon_runner.src.cli      import RunnerArgs
@@ -71,6 +72,10 @@ class TestHarness:
                     pkg_test_count = 0
                     log(f"Entering package {pkg.name}", indent=2)
                     for spkg in pkg.subpackages:
+                        # Glob pattern match against package_filter using subpackage path
+                        if self.config.package_filter:
+                            if not fnmatch.fnmatch(spkg.path.lower(), self.config.package_filter.lower()):
+                                continue
                         log(f"Entering subpackage {spkg.name}", indent=3)
                         counters = {"pass_count": 0, "test_count": 0}
                         self.pre_subpackage_hook(spkg)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,11 +17,14 @@ def create_cli_args(**kwargs) -> RunnerArgs:
         output     = kwargs.get('output_file', None),
         failure_log     = kwargs.get('failure_log', None),
         debug_package   = kwargs.get('debug_package', None),
+        package_filter  = kwargs.get('package_filter', None),
         mode            = kwargs.get('mode', None),
         timeout         = kwargs.get('timeout', 5),
         time            = kwargs.get('time', None),
         verbosity       = kwargs.get('verbosity', None),
         verify          = kwargs.get('verify', None),
+        show_testcase   = kwargs.get('show_testcase', None),
+        fast_fail       = kwargs.get('fast_fail', None),
     )
 
 @pytest.fixture(scope="session")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,12 @@
 import os
+from dragon_runner.src.cli import RunnerArgs, Mode
+from dragon_runner.src.config import load_config
+import fnmatch
 
-def test_valid_config(config_factory): 
+
+def test_valid_config(config_factory):
     config = config_factory("gccPassConfig.json")
-    
+
     assert config is not None
     assert config.test_dir is not None
     assert config.packages is not None
@@ -15,14 +19,54 @@ def test_valid_config(config_factory):
     assert config.error_collection == False
     assert os.path.exists(config.test_dir)
 
+
+def test_package_filter(config_factory):
+    """Test that subpackage filtering works correctly using glob pattern matching on paths"""
+
+    config_path = os.path.join(
+        os.path.dirname(__file__), "configs", "gccPassConfig.json"
+    )
+
+    # Load config - packages are always loaded, filtering happens at subpackage level
+    config = load_config(
+        config_path, RunnerArgs(mode=Mode.REGULAR, config_file=config_path)
+    )
+
+    # Collect all subpackages across all packages
+    all_subpackages = []
+    for pkg in config.packages:
+        for spkg in pkg.subpackages:
+            all_subpackages.append(spkg.path)
+
+    # Verify we have subpackages to test with
+    assert len(all_subpackages) > 0
+
+    # Test filter pattern "*ErrorPass*" - should match subpackages containing "ErrorPass" in path
+    filter_pattern = "*ErrorPass*"
+    filtered_subpackages = [
+        spkg_path
+        for spkg_path in all_subpackages
+        if fnmatch.fnmatch(spkg_path.lower(), filter_pattern.lower())
+    ]
+
+    # Should have some matches
+    assert len(filtered_subpackages) > 0
+
+    # All filtered subpackages should match the pattern (case insensitive)
+    for spkg_path in filtered_subpackages:
+        assert fnmatch.fnmatch(spkg_path.lower(), filter_pattern.lower())
+        assert "errorpass" in spkg_path.lower()
+
+
 def test_invalid_dir_config(config_factory):
     config = config_factory("invalidDirConfig.json")
-    
+
     assert config.error_collection == True
     assert not os.path.exists(config.test_dir)
 
+
 def test_invalid_exe_config(config_factory):
-    
+
     config = config_factory("invalidExeConfig.json")
 
     assert config.error_collection == True


### PR DESCRIPTION
Hey guys, this PR adds in a flag to allow glob matching for package name. 

The intent is to allow subsets of the testing suite to be ran instead of having to run the whole thing to speed of dev cycles without doing full "regression" style runs all the time. 